### PR TITLE
Exported utils module in __init__.py

### DIFF
--- a/console/__init__.py
+++ b/console/__init__.py
@@ -55,6 +55,7 @@ if _env.PY_CONSOLE_USE_TERMINFO.truthy or _env.SSH_CLIENT:
 # defer imports for proper ordering, read using_terminfo
 from .constants import TermLevel as _TermLevel
 from .detection import TermStack
+from . import utils
 
 
 # detection is performed if not explicitly disabled


### PR DESCRIPTION
The utils module of console is mentioned in a stackoverflow answer about waiting for key presses, but it's actually not exported outside the package so it's unusable :P